### PR TITLE
Fix swagger example

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "6.2.1",
-    "php-coveralls/php-coveralls": "dev-master",
+    "php-coveralls/php-coveralls": "^2.0",
     "squizlabs/php_codesniffer": "3.0.0"
   },
   "autoload": {

--- a/src/Model/ItemDescription.php
+++ b/src/Model/ItemDescription.php
@@ -14,19 +14,19 @@ class ItemDescription extends Model
     use TranslateTrait;
 
     /**
-     * @SWG\Property(example="Some sing, some cry")
+     * @SWG\Property(example="[In Library Use] REFLECTIONS OF CARTIER : THE ART DECO YEARS : NEW YORK EXHIBITION. [RECAP]")
      * @var string
      */
     public $title;
 
     /**
-     * @SWG\Property(example="Ifa Bayeza")
+     * @SWG\Property(example="Cartier, Louis, 1875-1942.   ")
      * @var string
      */
     public $author;
 
     /**
-     * @SWG\Property(example="|h*ONPA 84-446")
+     * @SWG\Property(example="|hJAX C-3278")
      * @var string
      */
     public $callNumber;

--- a/src/Model/RecapHoldRequestModel.php
+++ b/src/Model/RecapHoldRequestModel.php
@@ -14,25 +14,25 @@ abstract class RecapHoldRequestModel extends Model
     use TranslateTrait;
 
     /**
-     * @SWG\Property(example="901bdd1d-bd8f-4310-ba31-7f13a55877fd")
+     * @SWG\Property(example="51336")
      * @var string
      */
     public $trackingId;
 
     /**
-     * @SWG\Property(example="23333000000000")
+     * @SWG\Property(example="23333107857201")
      * @var string
      */
     public $patronBarcode;
 
     /**
-     * @SWG\Property(example="34333000000000")
+     * @SWG\Property(example="33433083079578")
      * @var string
      */
     public $itemBarcode;
 
     /**
-     * @SWG\Property(example="PUL")
+     * @SWG\Property(example="NYPL")
      * @var string
      */
     public $owningInstitutionId;


### PR DESCRIPTION
The example post request given in [https://platformdocs.nypl.org/#/recap-hold-requests/createRecapHoldRequest](url) is wrong (in particular the tracking id has an incorrect form), this PR is to change the example to match a sample kinesis event taken from production