### PR TITLE
Add samples and env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,7 @@
 # Private AWS configuration parameters to be used locally and for deployment by node-lambda
-
+AWS_ENVIRONMENT=development
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
 AWS_REGION=us-east-1
 AWS_FUNCTION_NAME=RecapHoldRequestService
 AWS_HANDLER=index.handler

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+vendor
+config/var_app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## CHANGELOG
 
-### 0.1.1
+### 1.0.0
 > Add samples/recap-hold-requests_schema.sql.
 > Add necessary envrionment variables in .env for running locally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## CHANGELOG
+
+### 0.1.1
+> Add samples/recap-hold-requests_schema.sql.
+> Add necessary envrionment variables in .env for running locally.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ php -S localhost:8888 -t . index.php
 
 You can then make a request to the Lambda: `http://localhost:8888/api/v0.1/recap/hold-requests`.
 
-For running locally properly, you will have to create a database that links to the local server. Use the schema in samples/recap-hold-requests_schema.sql to execute database dump. After that, set the right configurations of DB_CONNECT_STRING, DB_PASSWORD, DB_USERNAME in config/var_app.
+For running locally, you will have to create a database that links to the local server. Use the schema in samples/recap-hold-requests_schema.sql to execute database dump. Replace the [username] placeholder in the file with your user name. After that, set the right configurations of DB_CONNECT_STRING, DB_PASSWORD, DB_USERNAME in config/var_app.
 
 ### Event Documentation
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ php -S localhost:8888 -t . index.php
 
 You can then make a request to the Lambda: `http://localhost:8888/api/v0.1/recap/hold-requests`.
 
+For running locally properly, you will have to create a database that links to the local server. Use the schema in samples/recap-hold-requests_schema.sql to execute database dump. After that, set the right configurations of DB_CONNECT_STRING, DB_PASSWORD, DB_USERNAME in config/var_app.
+
 ### Event Documentation
 
 For more information on the different scenarios that involve RecapHoldRequestService, see:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "node-lambda": "^0.12.0",
-    "phplint": "~1.0.0"
+    "phplint": "2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "RecapHoldRequestService",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Lambda for the NYPL ReCAP Hold Request API Service",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "RecapHoldRequestService",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Lambda for the NYPL ReCAP Hold Request API Service",
   "main": "index.js",
   "scripts": {

--- a/samples/recap-hold-requests_schema.sql
+++ b/samples/recap-hold-requests_schema.sql
@@ -1,0 +1,210 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 9.5.4
+-- Dumped by pg_dump version 9.5.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+SET search_path = public, pg_catalog;
+
+--
+-- Name: recap_cancel_hold_request_id_seq; Type: SEQUENCE; Schema: public; Owner:
+--
+
+CREATE SEQUENCE recap_cancel_hold_request_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE recap_cancel_hold_request_id_seq OWNER TO [username];
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: recap_cancel_hold_request; Type: TABLE; Schema: public; Owner:
+--
+
+CREATE TABLE recap_cancel_hold_request (
+    tracking_id text,
+    owning_institution_id text,
+    job_id text,
+    created_date text,
+    updated_date text,
+    patron_barcode text,
+    item_barcode text,
+    processed boolean,
+    success boolean,
+    id integer DEFAULT nextval('recap_cancel_hold_request_id_seq'::regclass) NOT NULL
+);
+
+
+ALTER TABLE recap_cancel_hold_request OWNER TO [username];
+
+--
+-- Name: recap_hold_request_id_seq; Type: SEQUENCE; Schema: public; Owner:
+--
+
+CREATE SEQUENCE recap_hold_request_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE recap_hold_request_id_seq OWNER TO [username];
+
+--
+-- Name: recap_hold_request; Type: TABLE; Schema: public; Owner:
+--
+
+CREATE TABLE recap_hold_request (
+    id integer DEFAULT nextval('recap_hold_request_id_seq'::regclass) NOT NULL,
+    tracking_id text,
+    patron_barcode text,
+    item_barcode text,
+    created_date text,
+    updated_date text,
+    owning_institution_id text,
+    description text
+);
+
+
+ALTER TABLE recap_hold_request OWNER TO [username];
+
+--
+-- Name: recap_hold_request_id_pkey; Type: SEQUENCE; Schema: public; Owner:
+--
+
+CREATE SEQUENCE recap_hold_request_id_pkey
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE recap_hold_request_id_pkey OWNER TO [username];
+
+--
+-- Name: recap_cancel_hold_request_id_key; Type: CONSTRAINT; Schema: public; Owner:
+--
+
+ALTER TABLE ONLY recap_cancel_hold_request
+    ADD CONSTRAINT recap_cancel_hold_request_id_key UNIQUE (id);
+
+
+--
+-- Name: recap_cancel_hold_request_pkey; Type: CONSTRAINT; Schema: public; Owner:
+--
+
+ALTER TABLE ONLY recap_cancel_hold_request
+    ADD CONSTRAINT recap_cancel_hold_request_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: recap_hold_request_id_key; Type: CONSTRAINT; Schema: public; Owner:
+--
+
+ALTER TABLE ONLY recap_hold_request
+    ADD CONSTRAINT recap_hold_request_id_key UNIQUE (id);
+
+
+--
+-- Name: recap_hold_request_pkey; Type: CONSTRAINT; Schema: public; Owner:
+--
+
+ALTER TABLE ONLY recap_hold_request
+    ADD CONSTRAINT recap_hold_request_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: recap_cancel_hold_request_ids_idx; Type: INDEX; Schema: public; Owner:
+--
+
+CREATE INDEX recap_cancel_hold_request_ids_idx ON recap_cancel_hold_request USING btree (id, tracking_id, job_id);
+
+
+--
+-- Name: recap_hold_request_ids_idx; Type: INDEX; Schema: public; Owner:
+--
+
+CREATE INDEX recap_hold_request_ids_idx ON recap_hold_request USING btree (id, tracking_id);
+
+
+--
+-- Name: public; Type: ACL; Schema: -; Owner:
+--
+
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+REVOKE ALL ON SCHEMA public FROM [username];
+GRANT ALL ON SCHEMA public TO [username];
+GRANT ALL ON SCHEMA public TO PUBLIC;
+
+
+--
+-- Name: recap_cancel_hold_request_id_seq; Type: ACL; Schema: public; Owner:
+--
+
+REVOKE ALL ON SEQUENCE recap_cancel_hold_request_id_seq FROM PUBLIC;
+REVOKE ALL ON SEQUENCE recap_cancel_hold_request_id_seq FROM [username];
+GRANT ALL ON SEQUENCE recap_cancel_hold_request_id_seq TO [username];
+
+
+--
+-- Name: recap_cancel_hold_request; Type: ACL; Schema: public; Owner:
+--
+
+REVOKE ALL ON TABLE recap_cancel_hold_request FROM PUBLIC;
+REVOKE ALL ON TABLE recap_cancel_hold_request FROM [username];
+GRANT ALL ON TABLE recap_cancel_hold_request TO [username];
+
+
+--
+-- Name: recap_hold_request_id_seq; Type: ACL; Schema: public; Owner:
+--
+
+REVOKE ALL ON SEQUENCE recap_hold_request_id_seq FROM PUBLIC;
+REVOKE ALL ON SEQUENCE recap_hold_request_id_seq FROM [username];
+GRANT ALL ON SEQUENCE recap_hold_request_id_seq TO [username];
+
+
+--
+-- Name: recap_hold_request; Type: ACL; Schema: public; Owner:
+--
+
+REVOKE ALL ON TABLE recap_hold_request FROM PUBLIC;
+REVOKE ALL ON TABLE recap_hold_request FROM [username];
+GRANT ALL ON TABLE recap_hold_request TO [username];
+
+
+--
+-- PostgreSQL database dump complete
+--


### PR DESCRIPTION
When trying to test cancel-request-result-consumer, I ran into some issues from running recap-hold-request-service locally, which cancel-request-result-consumer does http PATCH to. The PR is for adding some more documentations and missing parts for solving the issues.

The PR adds the missing environment variables in `.env` for running this repo locally. Also, it adds a sql file for create a database that offers the proper tables for local server can connect to, which is needed for testing the repo locally.